### PR TITLE
Add empty lines between all main sections – and only between main sections

### DIFF
--- a/examples/example-unformatted.yml
+++ b/examples/example-unformatted.yml
@@ -11,6 +11,11 @@ tasks:
     # above cmds section
     cmds:
       - echo "Docker stuff"
+  with_vars:
+    cmds:
+      - echo "{{.VALUE}}"
+    vars:
+      VALUE: test
 env:
   NODE_ENV: development
 includes:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,12 +4,24 @@
 
 /**
  * Priority order for Taskfile top-level keys according to the style guide
+ *
+ * https://taskfile.dev/docs/styleguide#use-the-suggested-ordering-of-the-main-sections
  */
 export const TASKFILE_KEY_PRIORITY = [
   "version",
   "includes",
+  // "optional configurations" (cf. https://taskfile.dev/docs/styleguide#use-the-suggested-ordering-of-the-main-sections) in the order from https://taskfile.dev/docs/reference/schema#root-schema
+  "output",
+  "method",
+  "silent",
+  "run",
+  "interval",
+  "set",
+  "shopt",
+  // end of "optional configurations"
   "vars",
   "env",
+  "dotenv",
   "tasks",
 ] as const;
 
@@ -43,7 +55,7 @@ export const REGEX_PATTERNS = {
   TEMPLATE_WHITESPACE: /\{\{\s*\.\s*([A-Z0-9_]+)\s*\}\}/g,
 
   // Main section pattern
-  MAIN_SECTION: /^(version|includes|vars|env|tasks|tasks_with_templates):$/,
+  MAIN_SECTION: /^[a-z_][a-z0-9_:-]*:$/i,
 
   // Task definition pattern (2-space indented keys ending with colon)
   TASK_DEFINITION: /^  [a-zA-Z0-9_-]+:(\s|$)/,

--- a/src/formatters/key-sorter.spec.ts
+++ b/src/formatters/key-sorter.spec.ts
@@ -9,6 +9,16 @@ describe("sortTaskfileKeys", () => {
       vars: {},
       version: "3",
       custom: {},
+      dotenv: {},
+      output: {},
+      method: "checksum",
+      silent: false,
+      run: "always",
+      interval: "100ms",
+      set: [],
+      shopt: [],
+      templates: {},
+      defaults: {},
     };
 
     const result = sortTaskfileKeys(input);
@@ -17,10 +27,20 @@ describe("sortTaskfileKeys", () => {
     // Check priority order
     expect(keys[0]).toBe("version");
     expect(keys[1]).toBe("includes");
-    expect(keys[2]).toBe("vars");
-    expect(keys[3]).toBe("env");
-    expect(keys[4]).toBe("tasks");
-    expect(keys[5]).toBe("custom"); // Non-priority keys should be sorted alphabetically
+    expect(keys[2]).toBe("output");
+    expect(keys[3]).toBe("method");
+    expect(keys[4]).toBe("silent");
+    expect(keys[5]).toBe("run");
+    expect(keys[6]).toBe("interval");
+    expect(keys[7]).toBe("set");
+    expect(keys[8]).toBe("shopt");
+    expect(keys[9]).toBe("vars");
+    expect(keys[10]).toBe("env");
+    expect(keys[11]).toBe("dotenv");
+    expect(keys[12]).toBe("tasks");
+    expect(keys[13]).toBe("custom"); // Non-priority keys should be sorted alphabetically at the end of the list
+    expect(keys[14]).toBe("defaults");
+    expect(keys[15]).toBe("templates");
   });
 
   test("should handle missing keys", () => {
@@ -86,12 +106,15 @@ describe("sortTaskfileKeys", () => {
     // Check that priority keys come first
     expect(keys[0]).toBe("version");
     expect(keys[1]).toBe("includes");
-    expect(keys[2]).toBe("vars");
-    expect(keys[3]).toBe("env");
-    expect(keys[4]).toBe("tasks");
+    expect(keys[2]).toBe("output");
+    expect(keys[3]).toBe("method");
+    expect(keys[4]).toBe("silent");
+    expect(keys[5]).toBe("vars");
+    expect(keys[6]).toBe("env");
+    expect(keys[7]).toBe("tasks");
 
     // Check that other keys are sorted alphabetically
-    const otherKeys = keys.slice(5);
+    const otherKeys = keys.slice(7);
     const sortedOtherKeys = [...otherKeys].sort();
     expect(otherKeys).toEqual(sortedOtherKeys);
   });

--- a/src/render/add-empty-lines.ts
+++ b/src/render/add-empty-lines.ts
@@ -65,7 +65,7 @@ export function addEmptyLines(yamlStr: string): string {
       continue;
     }
 
-    const isMainSection = !!trimmedLine.match(REGEX_PATTERNS.MAIN_SECTION);
+    const isMainSection = !!line.match(REGEX_PATTERNS.MAIN_SECTION);
     const isTasksHeader = !!trimmedLine.match(
       /^(tasks|tasks_with_templates):$/,
     );

--- a/src/utils/line-formatter.spec.ts
+++ b/src/utils/line-formatter.spec.ts
@@ -13,6 +13,36 @@ describe("addEmptyLines", () => {
     expect(result).toContain("ENV: value\n\ntasks:");
   });
 
+  test("should add empty lines between custom main sections", () => {
+    const input = `tasks:
+  task:
+    cmds:
+      - echo "test"
+defaults:
+  DEFAULT: value
+custom:
+  CUSTOM: value
+# Comment for templates
+templates:
+  TEMPLATE: value
+`;
+    const result = addEmptyLines(input);
+
+    // Check for empty lines between sections
+    expect(result).toContain(`echo "test"
+
+defaults:`);
+    expect(result).toContain(`defaults:
+  DEFAULT: value
+
+custom:`);
+    expect(result).toContain(`custom:
+  CUSTOM: value
+
+# Comment for templates
+templates:`);
+  });
+
   test("should add empty lines between tasks", () => {
     const input =
       'tasks:\n  task1:\n    cmds:\n      - echo "test1"\n  task2:\n    cmds:\n      - echo "test2"';
@@ -329,5 +359,39 @@ tasks:
 
     expect(result.endsWith("  # trailing comment")).toBe(true);
     expect(result).toContain('echo "Building..."\n  # trailing comment');
+  });
+
+ test("should not add empty lines between sub sections with main section names", () => {
+    const input = `version: 3
+vars:
+  VAR: value
+tasks:
+  task_with_args:
+    cmd: "echo {{.VALUE}}"
+    vars:
+      VAR: value
+  task_with_env:
+    cmd: "echo {{.VALUE}}"
+    env:
+      ENV: value
+`;
+    const result = addEmptyLines(input);
+
+    expect(result).toEqual(`version: 3
+
+vars:
+  VAR: value
+
+tasks:
+  task_with_args:
+    cmd: "echo {{.VALUE}}"
+    vars:
+      VAR: value
+
+  task_with_env:
+    cmd: "echo {{.VALUE}}"
+    env:
+      ENV: value
+`);
   });
 });


### PR DESCRIPTION
Suggested fix for https://github.com/prettier-plugin-taskfile/prettier-plugin-taskfile/issues/7. The basic idea is to just identify main sections as YAML keys at the start of a line.

This happens to also fix https://github.com/prettier-plugin-taskfile/prettier-plugin-taskfile/issues/8.
